### PR TITLE
[qt5-qttools] Add run-time dependencies for qhelpgenerator

### DIFF
--- a/rpm/qttools.spec
+++ b/rpm/qttools.spec
@@ -138,6 +138,8 @@ This package contains the QtHelp library
 %package qthelp-devel
 Summary:    Development files for QtHelp
 Group:      Qt/Qt
+Requires:   qt5-plugin-sqldriver-sqlite
+Requires:   qt5-plugin-platform-minimal
 Requires(post):     /sbin/ldconfig
 Requires(postun):   /sbin/ldconfig
  


### PR DESCRIPTION
The qhelpgenerator application is a GUI application and requires a
platform integration plugin to be present. Fixed by adding a requires on
the minimal plugin.

Add a requires on the sqlite plugin which is needed to generate qch
files.
